### PR TITLE
fix(cost+supabase): align cost SQL with schema + trim env whitespace

### DIFF
--- a/apps/web/lib/supabase/client.ts
+++ b/apps/web/lib/supabase/client.ts
@@ -5,8 +5,12 @@
 import { createBrowserClient } from '@supabase/ssr';
 
 export function createSupabaseBrowserClient() {
+  // .trim() guards against stray whitespace pasted into the env var
+  // value (a trailing newline in the Vercel dashboard once produced
+  // an `apikey=...%0A` URL on the realtime websocket and broke every
+  // reconnect).
   return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_URL!.trim(),
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!.trim(),
   );
 }

--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -16,9 +16,10 @@ import { NextResponse, type NextRequest } from 'next/server';
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
+  // .trim() — see comment in client.ts
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_URL!.trim(),
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!.trim(),
     {
       cookies: {
         getAll() {

--- a/apps/web/lib/supabase/server.ts
+++ b/apps/web/lib/supabase/server.ts
@@ -15,9 +15,10 @@ import { cookies } from 'next/headers';
 
 export async function createSupabaseServerClient() {
   const cookieStore = await cookies();
+  // .trim() — see comment in client.ts
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_URL!.trim(),
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!.trim(),
     {
       cookies: {
         getAll() {

--- a/packages/api/src/helpers/cost.ts
+++ b/packages/api/src/helpers/cost.ts
@@ -38,12 +38,26 @@ export async function computeLiveCost(
   // Sum flight hours by category, matched against rates effective at
   // the time of each flight. Uses lateral join for rate resolution with
   // precedence: aircraft_id match > aircraft_make_model match > unscoped.
+  //
+  // Schema notes (post-Phase 5):
+  //   - flight_log_time stores per-row minute columns (day_minutes,
+  //     night_minutes, ...). There is no `hours` column. Total hours
+  //     for a row = (day_minutes + night_minutes) / 60.
+  //   - The flown date lives on flight_log_entry.flown_at, not on
+  //     flight_log_time.
+  //   - The flight_log_time_kind enum is constrained to:
+  //       dual_received, dual_given, pic, sic, solo
+  //     XC / night / IFR are NOT kinds — they're subset-minute columns
+  //     on each row. "Ground" instruction is not stored in this table.
+  //     Categorization here covers only what the kind enum exposes;
+  //     ground billing and IFR/XC surcharges are tracked as follow-up
+  //     work.
   const rows = (await tx.execute(sql`
     with student_times as (
       select
         flt.kind,
-        flt.hours,
-        flt.flown_at,
+        (flt.day_minutes + flt.night_minutes) / 60.0 as hours,
+        fle.flown_at,
         fle.aircraft_id,
         a.make_model as aircraft_make_model
       from public.flight_log_time flt
@@ -51,6 +65,7 @@ export async function computeLiveCost(
       left join public.aircraft a on a.id = fle.aircraft_id
       where flt.user_id = ${studentId}::uuid
         and fle.school_id = ${schoolId}::uuid
+        and flt.deleted_at is null
     ),
     rated as (
       select
@@ -61,12 +76,7 @@ export async function computeLiveCost(
           from public.school_rate sr
           where sr.school_id = ${schoolId}::uuid
             and sr.deleted_at is null
-            and sr.kind = case
-              when st.kind in ('pic','dual_received','solo','xc','night') then 'aircraft_wet'
-              when st.kind = 'ground' then 'ground_instructor'
-              when st.kind = 'ifr' then 'aircraft_wet'
-              else 'aircraft_wet'
-            end
+            and sr.kind = 'aircraft_wet'
             and sr.effective_from <= st.flown_at
             and (sr.effective_until is null or sr.effective_until > st.flown_at)
           order by
@@ -76,11 +86,7 @@ export async function computeLiveCost(
             sr.effective_from desc
           limit 1
         ) as rate_cents,
-        case
-          when st.kind in ('pic','dual_received','solo','xc','night','ifr') then 'aircraft'
-          when st.kind = 'ground' then 'ground'
-          else 'aircraft'
-        end as category,
+        'aircraft'::text as category,
         -- Also get instructor rate for dual_received
         case when st.kind = 'dual_received' then (
           select sr2.amount_cents
@@ -96,9 +102,9 @@ export async function computeLiveCost(
       from student_times st
     )
     select
-      coalesce(sum(case when category = 'aircraft' then (hours * coalesce(rate_cents, 0))::bigint else 0 end), 0)::bigint as aircraft_cents,
+      coalesce(sum((hours * coalesce(rate_cents, 0))::bigint), 0)::bigint as aircraft_cents,
       coalesce(sum(case when kind = 'dual_received' then (hours * coalesce(instructor_rate_cents, 0))::bigint else 0 end), 0)::bigint as instructor_cents,
-      coalesce(sum(case when category = 'ground' then (hours * coalesce(rate_cents, 0))::bigint else 0 end), 0)::bigint as ground_cents,
+      0::bigint as ground_cents,
       0::bigint as surcharge_cents,
       array_agg(distinct case when rate_cents is null then category else null end) filter (where rate_cents is null) as missing_rates
     from rated


### PR DESCRIPTION
## Summary

Two related fixes surfaced while UAT-testing #141:

1. **`computeLiveCost` SQL drift** — `cost.getForStudent` was 500'ing on every call (`column flt.hours does not exist`). React-Query retries amplified this into 100+ console errors on `/record`.
2. **Supabase client whitespace-resilience** — `NEXT_PUBLIC_SUPABASE_ANON_KEY` was pasted into Vercel with a trailing newline, breaking the realtime websocket on every reconnect (`apikey=...%0A`).

## What changed

### `packages/api/src/helpers/cost.ts` — align SQL with current schema

| Before | After | Reason |
|---|---|---|
| `flt.hours` | `(flt.day_minutes + flt.night_minutes) / 60.0` | `flight_log_time` stores per-row minute columns; no `hours` column. |
| `flt.flown_at` | `fle.flown_at` | The flown date lives on `flight_log_entry`. |
| CASE matches for `'xc'`, `'night'`, `'ifr'`, `'ground'` | removed | The `flight_log_time_kind` enum is `dual_received`/`dual_given`/`pic`/`sic`/`solo`. Removed branches were dead code masking the drift. |
| (no soft-delete filter) | `flt.deleted_at IS NULL` | Respect the table's soft-delete contract. |

### `apps/web/lib/supabase/{client,server,middleware}.ts` — `.trim()` env reads

Three call sites read `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` naked. Wrapped each in `.trim()`. No-op when env is clean.

## What this PR intentionally does NOT do

- **Ground billing**: still returns `0`. Ground instruction time isn't stored in `flight_log_time` in the current schema — needs a new data source.
- **IFR / XC / night surcharges**: still `0`. Needs richer rate model.
- **Pre-existing CI red on `main`** (broadcasts/messaging/notifications tests): unrelated, blocking merges.
- **Vercel env still has the trailing newline**: the trim fix is defensive belt-and-suspenders. Fixing the source value in the Vercel dashboard is still recommended.

## Verification

- `pnpm -r typecheck` — clean across all 8 workspaces
- `pnpm --filter @part61/api lint` — clean
- `pnpm --filter @part61/api test` — 13 pre-existing failures in broadcasts/messaging/notifications routers (already failing on `main`; unrelated). No cost tests exist.
- `apps/web` typechecks clean post-trim.

## Test plan

- [ ] Deploy preview comes up green
- [ ] Sign in as `student@tfs.test` on preview, visit `/record`
- [ ] No `cost.getForStudent` 500s in Network tab
- [ ] No cascading React Query retry errors in Console
- [ ] No Supabase realtime WebSocket failures (the `%0A` apikey URLs)
- [ ] `CostSummary` panel either shows a number or a clean empty state

## Follow-up (file as separate issues)

1. Ground instruction billing — schema-level decision needed
2. IFR / XC / night surcharge rates — product decision needed
3. Pre-existing CI red on `main` since Apr 23 — unrelated but blocks merges
4. Vercel env dashboard: strip trailing newline on the Supabase key
