### PR TITLE
fix(messaging-drawer): make close button discoverable + Esc-to-close

### DIFF
--- a/apps/web/components/MessagingDrawer.tsx
+++ b/apps/web/components/MessagingDrawer.tsx
@@ -109,6 +109,17 @@ export function MessagingDrawer({ currentUserId }: { currentUserId: string | nul
     markRead.mutate({ conversationId: activeConversationId });
   }, [open, activeConversationId]);
 
+  // Esc closes the drawer. Mirrors the tooltip on the close button so the
+  // affordance and the keybinding stay aligned.
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, setOpen]);
+
   if (!currentUserId) return null;
 
   const conversations = (convQ.data ?? []) as unknown as ConversationRow[];
@@ -148,7 +159,17 @@ export function MessagingDrawer({ currentUserId }: { currentUserId: string | nul
           type="button"
           onClick={() => setOpen(false)}
           aria-label="Close messages"
-          style={{ background: 'transparent', border: 0, cursor: 'pointer', fontSize: '1rem' }}
+          title="Close (Esc)"
+          style={{
+            background: 'transparent',
+            border: '1px solid #e5e7eb',
+            cursor: 'pointer',
+            fontSize: '1.1rem',
+            lineHeight: 1,
+            color: '#374151',
+            padding: '0.25rem 0.55rem',
+            borderRadius: 6,
+          }}
         >
           {'\u2715'}
         </button>


### PR DESCRIPTION
## Summary

The messaging drawer's close button existed but was visually invisible — a 1rem transparent `✕` with no border, no padding, no hover. Users opening a DM couldn't figure out how to dismiss the drawer.

Surfaced while UAT-testing #192 (Active Sessions admin page).

## What changed

**`apps/web/components/MessagingDrawer.tsx`**

1. **Visible close button**: explicit gray border (`#e5e7eb`), slightly larger glyph (`1.1rem`), comfortable padding (`0.25rem 0.55rem`), rounded corners. Still subtle, but now obviously interactive against the white drawer header.
2. **Esc-to-close**: keyboard listener attached while drawer is open, cleaned up on close/unmount. Mirrors the new `title="Close (Esc)"` tooltip.

## Verification

- `pnpm --filter web typecheck` — clean
- `pnpm --filter web lint` — clean
- Manual: drawer opens via DM button, Esc closes, click on the styled × button closes, no listener leaks.

## Test plan

- [ ] Sign in as any role, open messaging drawer (top-right toggle, or via DM button on /admin/active-sessions)
- [ ] Visible `[✕]` button in the drawer header — recognizable as a button
- [ ] Hover tooltip shows "Close (Esc)"
- [ ] Clicking it closes the drawer
- [ ] Pressing Esc closes the drawer
- [ ] Esc does nothing when the drawer is already closed (no stray listener)
