### PR TITLE
feat(admin/enrollments): reassign primary instructor

### DIFF
--- a/apps/web/app/(app)/admin/enrollments/ReassignInstructorDialog.tsx
+++ b/apps/web/app/(app)/admin/enrollments/ReassignInstructorDialog.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import { useEffect, useState, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { trpc } from '@/lib/trpc/client';
+
+interface ReassignInstructorDialogProps {
+  enrollmentId: string;
+  currentInstructorId: string | null;
+  currentInstructorName: string | null;
+  studentName: string | null;
+}
+
+/**
+ * Change the primary instructor on an existing enrollment.
+ *
+ * Calls admin.enrollments.reassignPrimaryInstructor with the picked
+ * instructor (or null to clear). The page is a server component, so on
+ * success we call router.refresh() — the trpc list query equivalent —
+ * to re-fetch the enrollments table.
+ */
+export function ReassignInstructorDialog({
+  enrollmentId,
+  currentInstructorId,
+  currentInstructorName,
+  studentName,
+}: ReassignInstructorDialogProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedInstructorId, setSelectedInstructorId] = useState<string>(
+    currentInstructorId ?? '',
+  );
+
+  const instructors = trpc.admin.people.list.useQuery(
+    { role: 'instructor', status: 'active', limit: 500, offset: 0 },
+    { enabled: open },
+  );
+
+  const reassign = trpc.admin.enrollments.reassignPrimaryInstructor.useMutation();
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeDialog();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  function closeDialog() {
+    setOpen(false);
+    setError(null);
+    setSelectedInstructorId(currentInstructorId ?? '');
+  }
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+
+    const newId = selectedInstructorId || null;
+    if (newId === (currentInstructorId ?? null)) {
+      closeDialog();
+      return;
+    }
+
+    try {
+      await reassign.mutateAsync({
+        enrollmentId,
+        newPrimaryInstructorId: newId,
+      });
+      closeDialog();
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Reassign failed.');
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        style={triggerStyle}
+        title="Reassign primary instructor"
+      >
+        Reassign…
+      </button>
+
+      {open ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Reassign primary instructor"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) closeDialog();
+          }}
+          style={overlay}
+        >
+          <form onSubmit={onSubmit} style={dialogShell}>
+            <div>
+              <div style={eyebrow}>Enrollment</div>
+              <h2 style={{ margin: '0.25rem 0 0', color: '#f7f9fc', fontSize: '1.1rem' }}>
+                Reassign primary instructor
+              </h2>
+              <p style={dialogSubcopy}>
+                {studentName ? (
+                  <>
+                    Student: <strong style={{ color: '#e2e8f0' }}>{studentName}</strong>
+                    <br />
+                  </>
+                ) : null}
+                Current:{' '}
+                <strong style={{ color: '#e2e8f0' }}>{currentInstructorName ?? '— None —'}</strong>
+              </p>
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
+              <label style={labelStyle}>New primary instructor</label>
+              <select
+                value={selectedInstructorId}
+                onChange={(e) => setSelectedInstructorId(e.target.value)}
+                style={inputStyle}
+                disabled={instructors.isLoading}
+              >
+                <option value="">— None —</option>
+                {((instructors.data?.rows ?? []) as Array<Record<string, unknown>>).map((p) => {
+                  const id = String(p.id);
+                  const first = (p.first_name as string | null) ?? '';
+                  const last = (p.last_name as string | null) ?? '';
+                  const email = (p.email as string) ?? '';
+                  const name = `${first} ${last}`.trim() || email;
+                  return (
+                    <option key={id} value={id}>
+                      {name}
+                    </option>
+                  );
+                })}
+              </select>
+            </div>
+
+            {error ? <div style={{ color: '#f87171', fontSize: '0.82rem' }}>{error}</div> : null}
+
+            <div
+              style={{
+                display: 'flex',
+                gap: '0.5rem',
+                justifyContent: 'flex-end',
+                alignItems: 'center',
+                marginTop: '0.25rem',
+              }}
+            >
+              <button type="button" onClick={closeDialog} style={ghostButton}>
+                Cancel
+              </button>
+              <button type="submit" style={primaryButton} disabled={reassign.isPending}>
+                {reassign.isPending ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+const triggerStyle: React.CSSProperties = {
+  display: 'inline-block',
+  padding: '0.25rem 0.6rem',
+  background: 'transparent',
+  border: '1px solid rgba(255,255,255,0.18)',
+  borderRadius: 6,
+  color: '#cbd5e1',
+  fontFamily: '"JetBrains Mono", ui-monospace, monospace',
+  fontSize: '0.68rem',
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  fontWeight: 600,
+  cursor: 'pointer',
+};
+
+const overlay: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(4, 8, 18, 0.72)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 50,
+  backdropFilter: 'blur(3px)',
+};
+
+const dialogShell: React.CSSProperties = {
+  width: '100%',
+  maxWidth: 480,
+  background: '#0d1220',
+  border: '1px solid rgba(255,255,255,0.1)',
+  borderRadius: 14,
+  padding: '1.25rem 1.35rem',
+  boxShadow: '0 20px 60px rgba(0,0,0,0.6)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+};
+
+const eyebrow: React.CSSProperties = {
+  fontSize: '0.66rem',
+  fontFamily: '"JetBrains Mono", ui-monospace, monospace',
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  color: '#7a869a',
+  fontWeight: 600,
+};
+
+const dialogSubcopy: React.CSSProperties = {
+  margin: '0.3rem 0 0',
+  fontSize: '0.82rem',
+  color: '#94a3b8',
+  lineHeight: 1.45,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: '0.68rem',
+  fontFamily: '"JetBrains Mono", ui-monospace, monospace',
+  letterSpacing: '0.14em',
+  textTransform: 'uppercase',
+  color: '#7a869a',
+  fontWeight: 600,
+};
+
+const inputStyle: React.CSSProperties = {
+  height: '2.3rem',
+  background: 'rgba(9, 13, 24, 0.85)',
+  border: '1px solid rgba(255,255,255,0.12)',
+  borderRadius: 8,
+  color: '#e2e8f0',
+  padding: '0 0.75rem',
+  fontSize: '0.88rem',
+  outline: 'none',
+  width: '100%',
+};
+
+const primaryButton: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  height: '2.3rem',
+  padding: '0 1rem',
+  background: 'linear-gradient(135deg, #fbbf24, #f59e0b)',
+  color: '#0a0e1a',
+  border: 'none',
+  borderRadius: 8,
+  fontSize: '0.88rem',
+  fontWeight: 700,
+  cursor: 'pointer',
+  letterSpacing: '0.01em',
+};
+
+const ghostButton: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  height: '2.3rem',
+  padding: '0 1rem',
+  background: 'transparent',
+  border: '1px solid rgba(255,255,255,0.14)',
+  borderRadius: 8,
+  color: '#cbd5e1',
+  fontSize: '0.82rem',
+  fontWeight: 600,
+  cursor: 'pointer',
+};

--- a/apps/web/app/(app)/admin/enrollments/page.tsx
+++ b/apps/web/app/(app)/admin/enrollments/page.tsx
@@ -5,6 +5,7 @@ import { db, users, studentCourseEnrollment } from '@part61/db';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { PageHeader } from '@/components/ui';
 import { NewEnrollmentDialog } from './NewEnrollmentDialog';
+import { ReassignInstructorDialog } from './ReassignInstructorDialog';
 
 export const dynamic = 'force-dynamic';
 
@@ -86,6 +87,7 @@ export default async function EnrollmentsPage() {
     select
       sce.id,
       sce.user_id as student_id,
+      sce.primary_instructor_id,
       sce.enrolled_at,
       sce.completed_at,
       sce.withdrawn_at,
@@ -95,12 +97,19 @@ export default async function EnrollmentsPage() {
         u.full_name,
         u.email
       ) as student_name,
+      coalesce(
+        nullif(trim(concat_ws(' ', ipp.first_name, ipp.last_name)), ''),
+        iu.full_name,
+        iu.email
+      ) as instructor_name,
       c.code as course_code,
       c.title as course_title,
       cv.version_label
     from public.student_course_enrollment sce
     join public.users u on u.id = sce.user_id
     left join public.person_profile pp on pp.user_id = sce.user_id
+    left join public.users iu on iu.id = sce.primary_instructor_id
+    left join public.person_profile ipp on ipp.user_id = sce.primary_instructor_id
     left join public.course_version cv on cv.id = sce.course_version_id
     left join public.course c on c.id = cv.course_id
     where sce.school_id = ${me.schoolId}::uuid
@@ -109,7 +118,9 @@ export default async function EnrollmentsPage() {
   `)) as unknown as Array<{
     id: string;
     student_id: string;
+    primary_instructor_id: string | null;
     student_name: string | null;
+    instructor_name: string | null;
     course_code: string | null;
     course_title: string | null;
     version_label: string | null;
@@ -146,7 +157,9 @@ function Section({
   rows: Array<{
     id: string;
     student_id: string;
+    primary_instructor_id: string | null;
     student_name: string | null;
+    instructor_name: string | null;
     course_code: string | null;
     course_title: string | null;
     version_label: string | null;
@@ -173,6 +186,7 @@ function Section({
                 <th style={TH}>Student</th>
                 <th style={TH}>Course</th>
                 <th style={TH}>Version</th>
+                <th style={TH}>Primary instructor</th>
                 <th style={TH}>Enrolled</th>
                 <th style={TH}></th>
               </tr>
@@ -207,6 +221,26 @@ function Section({
                   </td>
                   <td style={TD}>
                     {r.version_label ?? <span style={{ color: '#5b6784' }}>—</span>}
+                  </td>
+                  <td style={TD}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.5rem',
+                        flexWrap: 'wrap',
+                      }}
+                    >
+                      <span style={{ color: r.instructor_name ? '#f7f9fc' : '#5b6784' }}>
+                        {r.instructor_name ?? '—'}
+                      </span>
+                      <ReassignInstructorDialog
+                        enrollmentId={r.id}
+                        currentInstructorId={r.primary_instructor_id}
+                        currentInstructorName={r.instructor_name}
+                        studentName={r.student_name}
+                      />
+                    </div>
                   </td>
                   <td style={TD}>{new Date(r.enrolled_at).toLocaleDateString()}</td>
                   <td style={TD}>

--- a/packages/api/src/routers/admin/enrollments.ts
+++ b/packages/api/src/routers/admin/enrollments.ts
@@ -236,6 +236,64 @@ export const adminEnrollmentsRouter = router({
     }),
 
   /**
+   * Reassign (or clear) the primary instructor on an existing enrollment.
+   *
+   * The new instructor must belong to the caller's school AND carry the
+   * `instructor` role in user_roles. Passing null clears the assignment.
+   * The row's existing audit trigger (audit.attach on
+   * student_course_enrollment) records the change — no manual logging
+   * needed here.
+   */
+  reassignPrimaryInstructor: adminOrChiefInstructorProcedure
+    .input(
+      z.object({
+        enrollmentId: z.string().regex(/^[0-9a-fA-F-]{36}$/),
+        newPrimaryInstructorId: z
+          .string()
+          .regex(/^[0-9a-fA-F-]{36}$/)
+          .nullable(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const tx = ctx.tx as Tx;
+      const schoolId = ctx.session!.schoolId;
+
+      if (input.newPrimaryInstructorId !== null) {
+        const rows = (await tx.execute(sql`
+          select 1
+            from public.users u
+            join public.user_roles ur on ur.user_id = u.id
+            where u.id = ${input.newPrimaryInstructorId}::uuid
+              and u.school_id = ${schoolId}::uuid
+              and ur.role = 'instructor'
+            limit 1
+        `)) as unknown as Array<unknown>;
+        if (rows.length === 0) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Selected user is not an instructor in this school',
+          });
+        }
+      }
+
+      const [row] = await tx
+        .update(studentCourseEnrollment)
+        .set({ primaryInstructorId: input.newPrimaryInstructorId })
+        .where(
+          and(
+            eq(studentCourseEnrollment.id, input.enrollmentId),
+            eq(studentCourseEnrollment.schoolId, schoolId),
+            isNull(studentCourseEnrollment.deletedAt),
+          ),
+        )
+        .returning();
+      if (!row) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Enrollment not found' });
+      }
+      return row;
+    }),
+
+  /**
    * Phase 6 — getProgressForecast (SYL-22/23).
    *
    * Returns the cached forecast for an enrollment; refreshes if missing.

--- a/tests/rls/api-phase5-routers.test.ts
+++ b/tests/rls/api-phase5-routers.test.ts
@@ -195,6 +195,67 @@ describe('Phase 5-03 API routers', () => {
     expect(sc!.status).toBe('scheduled');
   });
 
+  it('admin.enrollments.reassignPrimaryInstructor swaps the primary CFI', async () => {
+    const caller = adminCaller({
+      userId: seed.userA,
+      schoolId: seed.schoolA,
+      activeBaseId: seed.baseA,
+    });
+    const row = await caller.admin.enrollments.reassignPrimaryInstructor({
+      enrollmentId,
+      newPrimaryInstructorId: otherInstructorId,
+    });
+    expect(row.primaryInstructorId).toBe(otherInstructorId);
+  });
+
+  it('admin.enrollments.reassignPrimaryInstructor clears the primary CFI when null', async () => {
+    const caller = adminCaller({
+      userId: seed.userA,
+      schoolId: seed.schoolA,
+      activeBaseId: seed.baseA,
+    });
+    const row = await caller.admin.enrollments.reassignPrimaryInstructor({
+      enrollmentId,
+      newPrimaryInstructorId: null,
+    });
+    expect(row.primaryInstructorId).toBeNull();
+  });
+
+  it('admin.enrollments.reassignPrimaryInstructor rejects a non-instructor user', async () => {
+    const caller = adminCaller({
+      userId: seed.userA,
+      schoolId: seed.schoolA,
+      activeBaseId: seed.baseA,
+    });
+    await expect(
+      caller.admin.enrollments.reassignPrimaryInstructor({
+        enrollmentId,
+        newPrimaryInstructorId: studentId, // student, not instructor
+      }),
+    ).rejects.toThrow(/instructor/i);
+  });
+
+  it('admin.enrollments.reassignPrimaryInstructor rejects a user from another school', async () => {
+    const caller = adminCaller({
+      userId: seed.userA,
+      schoolId: seed.schoolA,
+      activeBaseId: seed.baseA,
+    });
+    await expect(
+      caller.admin.enrollments.reassignPrimaryInstructor({
+        enrollmentId,
+        newPrimaryInstructorId: seed.userB, // admin of school B
+      }),
+    ).rejects.toThrow(/instructor/i);
+
+    // Restore primary instructor for subsequent tests that don't care
+    // either way, but it keeps the enrollment in a realistic shape.
+    await caller.admin.enrollments.reassignPrimaryInstructor({
+      enrollmentId,
+      newPrimaryInstructorId: instructorId,
+    });
+  });
+
   it('gradeSheet.createFromReservation + seal happy path', async () => {
     // Create a reservation tied to the lesson
     const caller = adminCaller({
@@ -287,9 +348,9 @@ describe('Phase 5-03 API routers', () => {
         gradeValue: 'I',
       });
     }
-    await expect(
-      caller.gradeSheet.seal({ gradeSheetId: sheet!.id }),
-    ).rejects.toThrow(/must-pass|must_pass/i);
+    await expect(caller.gradeSheet.seal({ gradeSheetId: sheet!.id })).rejects.toThrow(
+      /must-pass|must_pass/i,
+    );
   });
 
   it('admin.endorsements.issue renders {{placeholders}} into rendered_text', async () => {


### PR DESCRIPTION
## Summary
- Adds `admin.enrollments.reassignPrimaryInstructor({ enrollmentId, newPrimaryInstructorId })` (gated by `adminOrChiefInstructorProcedure`) that validates the new instructor (when non-null) belongs to the caller's school and has the `instructor` role, then updates the row. The existing `audit.attach` trigger on `student_course_enrollment` records the change.
- Wires a per-row **Reassign…** dialog into `/admin/enrollments`. The table now shows a "Primary instructor" column with the current name + a button that opens a picker (reusing the `admin.people.list({ role: 'instructor' })` pattern from `NewEnrollmentDialog`). "— None —" is supported to clear the assignment. `router.refresh()` is used to re-fetch on success since the page is a server component.
- Adds integration tests in `tests/rls/api-phase5-routers.test.ts` covering: happy-path swap, clearing with null, non-instructor user rejection, and cross-school user rejection.

Closes the gap surfaced in today's debug session where the only way to change a primary CFI after creation was to hand-edit the row in Supabase.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (incl. banned-terms)
- [ ] `pnpm --filter @part61/rls-tests test -- api-phase5-routers` against local Supabase Postgres (requires `pnpm supabase start`)
- [ ] Manual smoke: in `/admin/enrollments`, reassign a student from instructor A → instructor B; confirm the student disappears from A's `/dashboard` "Assigned Students" tile and appears on B's after refresh (data source: `me.getAssignedStudents` in `packages/api/src/routers/me.ts`).
- [ ] Manual smoke: clear primary instructor via "— None —"; row shows "—".

🤖 Generated with [Claude Code](https://claude.com/claude-code)